### PR TITLE
[Bugfix] Room-Delete now uses multi threading

### DIFF
--- a/app/src/main/java/com/archaeologicalfieldwork/room/Database.kt
+++ b/app/src/main/java/com/archaeologicalfieldwork/room/Database.kt
@@ -5,7 +5,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.archaeologicalfieldwork.models.SpotModel
 
-@Database(entities = arrayOf(SpotModel::class), version = 1,  exportSchema = false)
+@Database(entities = arrayOf(SpotModel::class), version = 2,  exportSchema = false)
 abstract class Database : RoomDatabase() {
 
     abstract fun spotDao(): SpotDao

--- a/app/src/main/java/com/archaeologicalfieldwork/views/spot/SpotPresenter.kt
+++ b/app/src/main/java/com/archaeologicalfieldwork/views/spot/SpotPresenter.kt
@@ -69,8 +69,12 @@ class SpotPresenter(view: BaseView) : BasePresenter(view) {
     }
 
     fun doDelete() {
-        app.spots.delete(spot)
-        view?.finish()
+        doAsync {
+            app.spots.delete(spot)
+            uiThread {
+                view?.finish()
+            }
+        }
     }
 
     fun doSelectImage() {
@@ -101,9 +105,17 @@ class SpotPresenter(view: BaseView) : BasePresenter(view) {
         map?.clear()
         map?.uiSettings?.isZoomGesturesEnabled = true
 
-        val options = MarkerOptions().title(spot.title).position(LatLng(spot.location.lat, spot.location.lng))
+        val options =
+            MarkerOptions().title(spot.title).position(LatLng(spot.location.lat, spot.location.lng))
         map?.addMarker(options)
-        map?.moveCamera(CameraUpdateFactory.newLatLngZoom(LatLng(spot.location.lat, spot.location.lng), spot.location.zoom))
+        map?.moveCamera(
+            CameraUpdateFactory.newLatLngZoom(
+                LatLng(
+                    spot.location.lat,
+                    spot.location.lng
+                ), spot.location.zoom
+            )
+        )
 
         view?.showSpot(spot)
     }
@@ -130,12 +142,12 @@ class SpotPresenter(view: BaseView) : BasePresenter(view) {
         permissions: Array<String>,
         grantResults: IntArray
     ) {
-            if (isPermissionGranted(requestCode, grantResults)) {
-                doSetCurrentLocation()
-            } else {
-                locationUpdate(Location(defaultLocation.lat, defaultLocation.lng))
-            }
+        if (isPermissionGranted(requestCode, grantResults)) {
+            doSetCurrentLocation()
+        } else {
+            locationUpdate(Location(defaultLocation.lat, defaultLocation.lng))
         }
+    }
 
     override fun doActivityResult(requestCode: Int, resultCode: Int, data: Intent) {
         when (requestCode) {


### PR DESCRIPTION
### Problem:
App crashed on Delete when using Room Database. Crash was caused, because delete was performed in uiThread.
<br>
### Solution:
- Now refactored SpotPresenter to use Multithreading for Deletion.
- Also increased version number of rooms, to keep up with changed SpotModel (fbID)
<br>
Closes #24 